### PR TITLE
Add rule name to rule create for ack-github

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ bx wsk action update ack-github actions/ack-github.py \
    --param github_creds GitHubWebHook --docker $WHISK_IMAGE
 
 # connect trigger to action with a rule
-bx wsk rule update GitHubWebHookIssues ack-github
+bx wsk rule update SendGitHubAck GitHubWebHookIssues ack-github
 
 ```
 


### PR DESCRIPTION
The docs in the README do not include a rule name in the rule create
command which causes the rule creation to fail.